### PR TITLE
sn/make-aws-anon-access-explicit

### DIFF
--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -400,6 +400,7 @@ def get_cloud_storage_instance(
             region=specific_attributes.get('region'),
             endpoint_url=specific_attributes.get('endpoint_url'),
             prefix=specific_attributes.get('prefix'),
+            anonymous_access = credentials.credentials_type == CredentialsTypeChoice.ANONYMOUS_ACCESS,
         )
     elif cloud_provider == CloudProviderChoice.AZURE_CONTAINER:
         instance = AzureBlobContainer(
@@ -434,6 +435,7 @@ class AWS_S3(_CloudStorage):
 
     def __init__(self,
                 bucket: str,
+                anonymous_access: bool = False,
                 *,
                 region: Optional[str] = None,
                 access_key_id: Optional[str] = None,
@@ -471,8 +473,8 @@ class AWS_S3(_CloudStorage):
             config=Config(proxies=PROXIES_FOR_UNTRUSTED_URLS or {}),
         )
 
-        # anonymous access
-        if not any([access_key_id, secret_key, session_token]):
+        # anonymous access - disable signing
+        if anonymous_access:
             self._s3.meta.client.meta.events.register(
                 "choose-signer.s3.*", disable_signing
             )
@@ -507,6 +509,8 @@ class AWS_S3(_CloudStorage):
                 return Status.FORBIDDEN
             else:
                 return Status.NOT_FOUND
+        except Exception as ex:
+            raise
 
     def get_file_status(self, key: str, /):
         try:

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -509,8 +509,6 @@ class AWS_S3(_CloudStorage):
                 return Status.FORBIDDEN
             else:
                 return Status.NOT_FOUND
-        except Exception as ex:
-            raise
 
     def get_file_status(self, key: str, /):
         try:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,8 +21,9 @@ services:
         CVAT_DEBUG_ENABLED:
         COVERAGE_PROCESS_START:
     environment:
-      AWS_ACCESS_KEY_ID: minio_access_key
-      AWS_SECRET_ACCESS_KEY: minio_secret_key
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-minio_access_key}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-minio_secret_key}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
       # Use this with CVAT_DEBUG_ENABLED to avoid server response timeouts
       CVAT_DEBUG_ENABLED: '${CVAT_DEBUG_ENABLED:-no}'
       CVAT_DEBUG_PORT: '9090'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,8 @@ services:
         CVAT_DEBUG_ENABLED:
         COVERAGE_PROCESS_START:
     environment:
+      AWS_ACCESS_KEY_ID: minio_access_key
+      AWS_SECRET_ACCESS_KEY: minio_secret_key
       # Use this with CVAT_DEBUG_ENABLED to avoid server response timeouts
       CVAT_DEBUG_ENABLED: '${CVAT_DEBUG_ENABLED:-no}'
       CVAT_DEBUG_PORT: '9090'

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -192,9 +192,7 @@ class TestPostCloudStorage:
             response_json = json.loads(response.data)
 
             assert (
-                DeepDiff(
-                    spec, response_json, ignore_order=True, exclude_paths=self._EXCLUDE_PATHS
-                )
+                DeepDiff(spec, response_json, ignore_order=True, exclude_paths=self._EXCLUDE_PATHS)
                 == {}
             )
 

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -5,7 +5,7 @@
 
 import io
 import json
-import copy
+from copy import deepcopy
 from functools import partial
 from http import HTTPStatus
 from typing import Any, Optional
@@ -238,7 +238,7 @@ class TestPostCloudStorage:
 
     def test_anonymous_access(self, users):
         username = [u for u in users if "user" in u["groups"]][0]["username"]
-        spec = copy.deepcopy(self._SPEC)
+        spec = deepcopy(self._SPEC)
         spec.update({
             "credentials_type": "ANONYMOUS_ACCESS",
             "resource": "public",
@@ -251,7 +251,7 @@ class TestPostCloudStorage:
     def test_env_credentials_fallback(self, users, monkeypatch):
         username = [u for u in users if "user" in u["groups"]][0]["username"]
 
-        spec = copy.deepcopy(self._SPEC)
+        spec = deepcopy(self._SPEC)
         spec.pop("key", None)
         spec.pop("secret_key", None)
 

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -237,6 +237,8 @@ class TestPostCloudStorage:
     def test_anonymous_access(self, users):
         username = [u for u in users if "user" in u["groups"]][0]["username"]
         spec = deepcopy(self._SPEC)
+
+        # set anonymous access and try to access the public bucket
         spec.update(
             {
                 "credentials_type": "ANONYMOUS_ACCESS",
@@ -252,6 +254,7 @@ class TestPostCloudStorage:
         username = [u for u in users if "user" in u["groups"]][0]["username"]
 
         spec = deepcopy(self._SPEC)
+        # completely remove credentials, these should then be pulled from environment
         spec.pop("key", None)
         spec.pop("secret_key", None)
 

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -239,10 +239,12 @@ class TestPostCloudStorage:
     def test_anonymous_access(self, users):
         username = [u for u in users if "user" in u["groups"]][0]["username"]
         spec = deepcopy(self._SPEC)
-        spec.update({
-            "credentials_type": "ANONYMOUS_ACCESS",
-            "resource": "public",
-        })
+        spec.update(
+            {
+                "credentials_type": "ANONYMOUS_ACCESS",
+                "resource": "public",
+            }
+        )
         spec.pop("key", None)
         spec.pop("secret_key", None)
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Currently there is no way to use the environmental credentials chain for aws cloud storages. You must either explicitly set your credentials or cvat will assume you are attempting to do anonymous access and signing requests will be disabled entirely. I added the ability for the credentials type to be specified and passed on to the aws provider. If anonymous is requested, then signing requests will still be disabled. If credentials are given, they will be used to access aws, if credentials are not explicitly given, boto3 will look for them in the environment.

### How has this been tested?
Added rest api tests for adding a cloud storage. One test to show anonymous access was still supported, and a second test to show that the aws provider could pull creds from the environment

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
